### PR TITLE
feat: Improve matspec speed when INTERACTIVE=FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: mva.plots
 Title: Add visualisation capabilities to multivariate analysis
-Version: 0.0.6
+Version: 0.0.7
 Authors@R: 
     person("Lucy", "Grigoroff", , "Lucy.Grigoroff@murdoch.edu.au", role = c("aut", "cre"),
            comment = c(ORCID = "o"))
@@ -10,6 +10,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Config/testthat/edition: 3
+biocViews:
 Imports:
     caret,
     crayon,
@@ -25,8 +26,7 @@ Imports:
     scales,
     BiocManager (>= 1.30.16),
     stats,
-    sf
-biocViews:
+    sf,
     ropls
 Suggests: 
     knitr,

--- a/R/matspec.R
+++ b/R/matspec.R
@@ -84,17 +84,30 @@ matspec<-function (X, ppm, roi = c(0.5, 9.5), interactive = TRUE, ...)
     p <- suppressWarnings(add_lines(p = p))
 
     return(p)
+  } else {
+    ####non-interactive plot####
+    # We can re-sample to have 1 data point by pixel and get the result faster.
+    figSizeInPx <- dev.size(units = "px")# width, height
+    if(all(is.na(figSizeInPx))) {
+      figSizeInPx <- c(600, 400)
+    }
+    # We can suppose that all the pixels are used for data points. That is not completely true, but it is a good guess
+    pointsPerPixel <- ceiling(length(fi) / figSizeInPx[[1]])
+    # Simple re-sampling function.
+    for (i in 1:length(fi)) {
+      if ((i %% pointsPerPixel) != 0) {
+        fi[[i]] <- FALSE
+      }
+    }
+
+    matplot(ppm[fi],
+            t(X[, fi]),
+            type = "l",
+            xlim = rev(range(ppm[fi])),
+            xlab = "ppm",
+            ylab = "Intensity",
+            ...)
   }
-
-####non-interactive plot####
-  matplot(ppm[fi],
-          t(X[, fi]),
-          type = "l",
-          xlim = rev(range(ppm[fi])),
-          xlab = "ppm",
-          ylab = "Intensity",
-          ...)
-
 }
 
 


### PR DESCRIPTION
I change the code to use only one data point per pixel when INTERACTIVE=FALSE. If we have 1000 spectra of 64K, and an image of only 600 pixels, this method improves the speed more than 10 times.